### PR TITLE
Build Focal and Bookworm images

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -18,12 +18,24 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: 'Build docker image'
+      - name: 'Build Jammy docker image'
         uses: ./.github/actions/with-docker
         with:
           os: ubuntu
           distro: jammy
           image-tag: runtimeverificationinc/ubuntu-jammy-z3
+      - name: 'Build Focal docker image'
+        uses: ./.github/actions/with-docker
+        with:
+          os: ubuntu
+          distro: focal
+          image-tag: runtimeverificationinc/ubuntu-focal-z3
+      - name: 'Build Debian Bookworm docker image'
+        uses: ./.github/actions/with-docker
+        with:
+          os: debian
+          distro: bookworm
+          image-tag: runtimeverificationinc/debian-bookworm-z3
       - name: 'Login to dockerhub'
         uses: docker/login-action@v2
         with:
@@ -33,6 +45,8 @@ jobs:
         run: |
           version=$(cat version)
           docker image push runtimeverificationinc/ubuntu-jammy-z3:${version}
+          docker image push runtimeverificationinc/ubuntu-focal-z3:${version}
+          docker image push runtimeverificationinc/debian-bookworm-z3:${version}
 
   make-release:
     name: 'Update dependents'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,9 +18,21 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: 'Build docker image'
+      - name: 'Build Jammy docker image'
         uses: ./.github/actions/with-docker
         with:
           os: ubuntu
           distro: jammy
-          image-tag: ubuntu-jammy-z3
+          image-tag: runtimeverificationinc/ubuntu-jammy-z3
+      - name: 'Build Focal docker image'
+        uses: ./.github/actions/with-docker
+        with:
+          os: ubuntu
+          distro: focal
+          image-tag: runtimeverificationinc/ubuntu-focal-z3
+      - name: 'Build Debian Bookworm docker image'
+        uses: ./.github/actions/with-docker
+        with:
+          os: debian
+          distro: bookworm
+          image-tag: runtimeverificationinc/debian-bookworm-z3


### PR DESCRIPTION
The lack of images for Ubuntu Focal and Debian Bookworm is currently breaking the K release job (see [here](https://github.com/runtimeverification/k/actions/runs/6458863473/job/17533447223) for an example run where the relevant job has failed).

This PR adds stanzas to the test and release workflows to build these images using the existing parameterised workflow from this repository.

Note that there has been some discussion [elsewhere](https://github.com/runtimeverification/k/issues/3591) re. removing support for Ubuntu Focal, but as this is breaking the release build we should make that change consistently at one time if we decide to do so.